### PR TITLE
Add string comparison generators

### DIFF
--- a/src/Hedgehog.Experimental/Gen.fs
+++ b/src/Hedgehog.Experimental/Gen.fs
@@ -26,6 +26,32 @@
     let cString (lower : int) (upper : int) : (Gen<char> -> Gen<string>) =
         string (Range.constant lower upper)
 
+    /// Generates a string that is not equal to another string using
+    /// StringComparison.OrdinalIgnoreCase.
+    let iNotEqualTo (str : string) : (Gen<string> -> Gen<string>) =
+        filter <| fun s ->
+            not <| str.Equals(s, System.StringComparison.OrdinalIgnoreCase)
+
+    /// Generates a string that is not a substring of another string.
+    let notSubstringOf (str : string) : (Gen<string> -> Gen<string>) =
+      filter <| fun s -> not <| str.Contains s
+
+    /// Generates a string that is not a substring of another string using
+    /// StringComparison.OrdinalIgnoreCase.
+    let iNotSubstringOf (str : string) : (Gen<string> -> Gen<string>) =
+      filter <| fun s ->
+          str.IndexOf(s, System.StringComparison.OrdinalIgnoreCase) = -1
+
+    /// Generates a string that does not start with another string.
+    let notStartsWith (str : string) : (Gen<string> -> Gen<string>) =
+      filter <| fun s -> not <| s.StartsWith str
+
+    /// Generates a string that does not start with another string using
+    /// StringComparison.OrdinalIgnoreCase.
+    let iNotStartsWith (str : string) : (Gen<string> -> Gen<string>) =
+      filter <| fun s ->
+        not <| s.StartsWith(str, System.StringComparison.OrdinalIgnoreCase)
+
     /// Generates null part of the time.
     let withNull (g : Gen<'a>) : Gen<'a> =
         g |> option |> map (fun xOpt ->


### PR DESCRIPTION
Might need some discussion (we briefly touched a few issues in [this comment](https://github.com/hedgehogqa/fsharp-hedgehog/pull/140#issuecomment-338619271)).

In short, I think having separate functions for case sensitive and case insensitive comparisons makes sense, and I think prefixing the case insensitive functions with `i` makes make sense:
* Users wanting this functionality are probably writing `Gen.substring` to see which functions turn up in Intellisense, and the function documentation makes it immediately clear what the `i`-prefixed functions do
* IMHO the naming is easy to understand and remember
* Importantly, it's short - compare to e.g. `notSubstringOfIgnoringCase`, which is awfully long and starts to defeat the purpose of having these convenience generators in the first place
* Parametrizing the functions by e.g. the `System.StringComparison` enum is even worse - at that point, you can just as well write the full filter

Before merging:

* [ ] Agree on generators and names
* [ ] Add tests