### PR TITLE
simplified withNull test by using Gen.sample

### DIFF
--- a/src/Hedgehog.Experimental.Tests/GenTests.fs
+++ b/src/Hedgehog.Experimental.Tests/GenTests.fs
@@ -90,10 +90,10 @@ let ``iNotStartsWith does not generate a string that starts with another string 
 
 [<Fact>]
 let ``withNull generates null some of the time`` () =
-    Property.check' 1<tests> <| property {
-        let! xs = Gen.constant "a" |> GenX.withNull |> Gen.list (Range.singleton 1000)
-        test <@ xs |> List.exists isNull @>
-    }
+    Gen.constant "a"
+    |> GenX.withNull
+    |> Gen.sample 0 1000
+    |> Seq.exists isNull
 
 [<Fact>]
 let ``noNull does not generate nulls`` () =


### PR DESCRIPTION
This PR has the same goal as #41 but does a much better job.  This code is more idiomatic, the code is shorter, I think the `Hedgehog.Gen.sample` API is stable (though its return type could replace `List` with `seq` to improve performance, but I used `Seq.exists` in this code, so it will continue to work if that change occurs).

This implementation of `Hedgehog.Gen.sample` is essentially the same as the code I wrote in PR #41.  I just learned of its existence.