### PR TITLE
Isolate mutations from calls to Gen.bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 0.4.1
+* The `Gen.auto` cases for records, classes, discriminated unions, and tuples now shrink correctly.
+
 ### 0.4.0 (2021-02-07)
 
 * Updated for Hedgehog 0.10.0


### PR DESCRIPTION
Revolves #52

...by working around https://github.com/hedgehogqa/fsharp-hedgehog/issues/192.

@dharmaturtle, after this completes and a new version is released, you should update `Hedgehog.Xunit` to require this new version and make a release so that users get this bug fix.  