### PR TITLE
Fixes shrinking for shuffleCase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 0.4.1
 * The `Gen.auto` cases for records, classes, discriminated unions, and tuples now shrink correctly.
+* The function `shuffleCase` now shrinks correctly
 
 ### 0.4.0 (2021-02-07)
 

--- a/src/Hedgehog.Experimental.Tests/GenTests.fs
+++ b/src/Hedgehog.Experimental.Tests/GenTests.fs
@@ -770,3 +770,13 @@ let ``auto of tuple shrinks correctly`` () =
   let report = Property.report property
   let rendered = Report.render report
   test <@ rendered.Contains "(\"b\", 0)" @>
+
+[<Fact>]
+let ``shuffleCase shrinks correctly`` () =
+  let property = property {
+    let! value = GenX.shuffleCase "abcdefg"
+    test <@ not (value.StartsWith "A") @>
+  }
+  let report = Property.report property
+  let rendered = Report.render report
+  test <@ rendered.Contains "\"Abcdefg\".StartsWith(\"A\")" @>

--- a/src/Hedgehog.Experimental/Gen.fs
+++ b/src/Hedgehog.Experimental/Gen.fs
@@ -164,14 +164,16 @@ module GenX =
 
   /// Shuffles the case of the given string.
   let shuffleCase (s: string) =
-    gen {
-     let sb = Text.StringBuilder()
-     for i = 0 to s.Length - 1 do
-       let! b = Gen.bool
-       let f = if b then Char.ToUpperInvariant else Char.ToLowerInvariant
-       sb.Append (f s.[i]) |> ignore
-     return sb.ToString()
-    }
+    Gen.bool
+    |> List.replicate s.Length
+    |> ListGen.sequence
+    |> Gen.map (fun bs ->
+      let sb = Text.StringBuilder ()
+      bs
+      |> List.iteri (fun i b ->
+        let f = if b then Char.ToUpperInvariant else Char.ToLowerInvariant
+        sb.Append (f s.[i]) |> ignore)
+      sb.ToString())
 
   /// Generates a string that is not equal to another string using
   /// StringComparison.OrdinalIgnoreCase.


### PR DESCRIPTION
Workaround for https://github.com/hedgehogqa/fsharp-hedgehog/issues/157 that fixes the specific issue in https://github.com/hedgehogqa/fsharp-hedgehog/issues/192, which is that shrinking for `shuffleCase` doesn't work correctly.

As with PR #51, the fix is to obtain all of the generators first, then swap `List` and `Gen` (via `sequence` this time), then mutate inside `Gen.map`.

Also as with PR #51, there is a test that shows this is an improvement.

I am also looking at the mutation in `shuffle`, but I haven't been able write a test for that case yet, so this PR is just for `shuffleCase`.