### PR TITLE
Delay mutations in shuffle so shirking is correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 0.4.1
 * The `Gen.auto` cases for records, classes, discriminated unions, and tuples now shrink correctly.
 * The function `shuffleCase` now shrinks correctly
+* The function `shuffle` now shrinks correctly
 
 ### 0.4.0 (2021-02-07)
 

--- a/src/Hedgehog.Experimental.Tests/GenTests.fs
+++ b/src/Hedgehog.Experimental.Tests/GenTests.fs
@@ -779,4 +779,4 @@ let ``shuffleCase shrinks correctly`` () =
   }
   let report = Property.report property
   let rendered = Report.render report
-  test <@ rendered.Contains "\"Abcdefg\".StartsWith(\"A\")" @>
+  test <@ rendered.Contains "\"Abcdefg\"" @>

--- a/src/Hedgehog.Experimental.Tests/GenTests.fs
+++ b/src/Hedgehog.Experimental.Tests/GenTests.fs
@@ -780,3 +780,20 @@ let ``shuffleCase shrinks correctly`` () =
   let report = Property.report property
   let rendered = Report.render report
   test <@ rendered.Contains "\"Abcdefg\"" @>
+
+[<Fact>]
+let ``shuffle shrinks correctly`` () =
+  let property = property {
+    let n = 10
+    let nMinus1 = n - 1
+    let! value =
+      ()
+      |> Seq.replicate n
+      |> Seq.mapi (fun i _ -> i)
+      |> Seq.toList
+      |> GenX.shuffle
+    test <@ nMinus1 <> value.Head @>
+  }
+  let report = Property.report property
+  let rendered = Report.render report
+  test <@ rendered.Contains "[9; 0; 1; 2; 3; 4; 5; 6; 7; 8]" @>

--- a/src/Hedgehog.Experimental/Gen.fs
+++ b/src/Hedgehog.Experimental/Gen.fs
@@ -153,14 +153,17 @@ module GenX =
   /// Generates a permutation of the given list.
   // "Inside-out" algorithm of Fisher-Yates shuffle from https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_%22inside-out%22_algorithm
   let shuffle (xs: 'a list) =
-    gen {
+    xs
+    |> List.mapi (fun i _ -> Gen.integral (Range.constant 0 i))
+    |> ListGen.sequence
+    |> Gen.map (fun list ->
       let shuffled = Array.zeroCreate<'a>(xs.Length)
-      for i = 0 to xs.Length - 1 do
-        let! j = Gen.integral (Range.constant 0 i)
-        if i <> j then shuffled.[i] <- shuffled.[j]
-        shuffled.[j] <- xs.[i]
-      return shuffled |> Array.toList
-    }
+      list
+      |> List.zip xs
+      |> List.iteri (fun i (a, j) ->
+        shuffled.[i] <- shuffled.[j]
+        shuffled.[j] <- a)
+      shuffled |> Array.toList)
 
   /// Shuffles the case of the given string.
   let shuffleCase (s: string) =


### PR DESCRIPTION
Workaround of https://github.com/hedgehogqa/fsharp-hedgehog/issues/157 for the function `shuffle`.

This change also improves the runtime from quadratic to linear.  The previous runtime was quadratic because of the calls to `xs.Length` and `xs.[i]` inside the loop, both of which have linear runtime.

As mentioned in [the Wikipedia article](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#:~:text=the%20condition%20that%20checks%20if%20j%20%3D%20i%20may%20be%20omitted%20in%20languages%20that%20have%20no%20problems%20accessing%20uninitialized%20array%20values.), I dropped the guard `i <> j` because we don't need it.

Let's delay a release a bit longer.  I want to see if there is anything else I can improve.