### PR TITLE
Update to .NET 8 because .NET 6 is no longer supported

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.201
+        dotnet-version: 8
     - name: Build
       run: dotnet build -c Release src
     - name: Test F#

--- a/src/Hedgehog.Experimental.CSharp.Tests/Hedgehog.Experimental.CSharp.Tests.csproj
+++ b/src/Hedgehog.Experimental.CSharp.Tests/Hedgehog.Experimental.CSharp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/Hedgehog.Experimental.Tests/Hedgehog.Experimental.Tests.fsproj
+++ b/src/Hedgehog.Experimental.Tests/Hedgehog.Experimental.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>

--- a/src/Hedgehog.Experimental/Hedgehog.Experimental.fsproj
+++ b/src/Hedgehog.Experimental/Hedgehog.Experimental.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
## Description

.NET 6 went out of life/support in November 2024.
The next/current LTS is .NET 8 and it is supported until the end of 2026.